### PR TITLE
feat: add golang entrypoint

### DIFF
--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -217,8 +217,6 @@ const goSubLanguages: Array<Pick<SALanguage, 'chapter' | 'variant' | 'displayNam
   { chapter: Chapter.GO_1, variant: Variant.EXPLICIT_CONTROL, displayName: 'Go \xa71' }
 ];
 
-console.log(Chapter);
-
 export const goLanguages: SALanguage[] = goSubLanguages.map(sublang => {
   return { ...sublang, mainLanguage: SupportedLanguage.GO, supports: { repl: false } };
 });

--- a/src/commons/application/ApplicationTypes.ts
+++ b/src/commons/application/ApplicationTypes.ts
@@ -123,13 +123,15 @@ export enum StoriesRole {
 export enum SupportedLanguage {
   JAVASCRIPT = 'JavaScript',
   SCHEME = 'Scheme',
-  PYTHON = 'Python'
+  PYTHON = 'Python',
+  GO = 'Go'
 }
 
 export const SUPPORTED_LANGUAGES = [
   SupportedLanguage.JAVASCRIPT,
   SupportedLanguage.SCHEME,
-  SupportedLanguage.PYTHON
+  SupportedLanguage.PYTHON,
+  SupportedLanguage.GO
 ];
 
 /**
@@ -211,6 +213,16 @@ export const pyLanguages: SALanguage[] = pySubLanguages.map(sublang => {
   return { ...sublang, mainLanguage: SupportedLanguage.PYTHON, supports: { repl: true } };
 });
 
+const goSubLanguages: Array<Pick<SALanguage, 'chapter' | 'variant' | 'displayName'>> = [
+  { chapter: Chapter.GO_1, variant: Variant.EXPLICIT_CONTROL, displayName: 'Go \xa71' }
+];
+
+console.log(Chapter);
+
+export const goLanguages: SALanguage[] = goSubLanguages.map(sublang => {
+  return { ...sublang, mainLanguage: SupportedLanguage.GO, supports: { repl: false } };
+});
+
 export const styliseSublanguage = (chapter: Chapter, variant: Variant = Variant.DEFAULT) => {
   return getLanguageConfig(chapter, variant).displayName;
 };
@@ -279,7 +291,8 @@ export const ALL_LANGUAGES: readonly SALanguage[] = [
   fullTSLanguage,
   htmlLanguage,
   ...schemeLanguages,
-  ...pyLanguages
+  ...pyLanguages,
+  ...goLanguages
 ];
 // TODO: Remove this function once logic has been fully migrated
 export const getLanguageConfig = (

--- a/src/commons/application/__tests__/ApplicationTypes.ts
+++ b/src/commons/application/__tests__/ApplicationTypes.ts
@@ -3,6 +3,7 @@ import { Chapter, Variant } from 'js-slang/dist/types';
 import {
   ALL_LANGUAGES,
   getLanguageConfig,
+  goLanguages,
   pyLanguages,
   schemeLanguages,
   sourceLanguages
@@ -113,5 +114,11 @@ describe('available Python language configurations', () => {
 describe('available Scheme language configurations', () => {
   test('matches snapshot', () => {
     expect(schemeLanguages).toMatchSnapshot();
+  });
+});
+
+describe('available Go language configurations', () => {
+  test('matches snapshot', () => {
+    expect(goLanguages).toMatchSnapshot();
   });
 });

--- a/src/commons/application/__tests__/__snapshots__/ApplicationTypes.ts.snap
+++ b/src/commons/application/__tests__/__snapshots__/ApplicationTypes.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`available Go language configurations matches snapshot 1`] = `
+Array [
+  Object {
+    "chapter": -14,
+    "displayName": "Go §1",
+    "mainLanguage": "Go",
+    "supports": Object {
+      "repl": false,
+    },
+    "variant": "explicit-control",
+  },
+]
+`;
+
 exports[`available Python language configurations matches snapshot 1`] = `
 Array [
   Object {

--- a/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import {
   fullJSLanguage,
   fullTSLanguage,
+  goLanguages,
   htmlLanguage,
   pyLanguages,
   SALanguage,
@@ -87,7 +88,8 @@ export const ControlBarChapterSelect: React.FC<ControlBarChapterSelectProps> = (
     // See https://github.com/source-academy/frontend/pull/2460#issuecomment-1528759912
     ...(Constants.playgroundOnly ? [fullJSLanguage, fullTSLanguage, htmlLanguage] : []),
     ...schemeLanguages,
-    ...pyLanguages
+    ...pyLanguages,
+    ...goLanguages
   ];
 
   return (

--- a/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   getLanguageConfig,
+  goLanguages,
   pyLanguages,
   SALanguage,
   schemeLanguages,
@@ -21,7 +22,8 @@ const defaultSublanguages: {
 } = {
   [SupportedLanguage.JAVASCRIPT]: sourceLanguages[0],
   [SupportedLanguage.PYTHON]: pyLanguages[0],
-  [SupportedLanguage.SCHEME]: schemeLanguages[0]
+  [SupportedLanguage.SCHEME]: schemeLanguages[0],
+  [SupportedLanguage.GO]: goLanguages[0]
 };
 
 const NavigationBarLangSelectButton = () => {

--- a/src/commons/utils/AceHelper.ts
+++ b/src/commons/utils/AceHelper.ts
@@ -50,6 +50,8 @@ export const getModeString = (chapter: Chapter, variant: Variant, library: strin
     case Chapter.SCHEME_4:
     case Chapter.FULL_SCHEME:
       return 'scheme';
+    case Chapter.GO_1:
+      return 'golang';
     default:
       return `source${chapter}${variant}${library}`;
   }


### PR DESCRIPTION
# Description

This is a simple/short PR to set up the entry point for `golang` on the frontend. The PR sets up **Go** as a language that a user can choose, but it does not yet support the running a `.go` program yet, however it does support `.go` syntax highlighting 🥳

The accompanying `go-slang` PR: https://github.com/shenyih0ng/go-slang/pull/1

## Setting up dev environment

There is currently no good way to test out `go-slang` with a frontend. Although the 2 repos are tightly coupled, they remain as independent repos which means that we will need to `yarn/npm link` the repos.

1. `yarn link` in `go-slang` repo
2. `yarn link js-slang` in the `frontend` repo
    - `js-slang` is used here since the package name has not been changed to `go-slang`, and i don't think we should be changing?
4. At this point `frontend` should be using a local build of `go-slang` instead of the one released on the registry
5. For every new feature/modification to `go-slang`, you will need to run `yarn build` in the `go-slang` repo so that the latest changes are built and updated in the `/dist` folder (that's the folder that `frontend` is using after linking)